### PR TITLE
[update] 文字色の指定に color.NRGBA を使用するよう修正

### DIFF
--- a/internal/color/color.go
+++ b/internal/color/color.go
@@ -1,4 +1,4 @@
-// package color は 16 進数のカラーコードから color.RGBA を生成するパッケージです。
+// package color は 16 進数のカラーコードから color.NRGBA を生成するパッケージです。
 package color
 
 import (
@@ -16,9 +16,9 @@ var rgbaFormat = regexp.MustCompile(`^#[0-9a-fA-F]{2}[0-9a-fA-F]{2}[0-9a-fA-F]{2
 // rgbFormat はアルファ値を含まないカラーコードを判定するための正規表現です。
 var rgbFormat = regexp.MustCompile(`^#[0-9a-fA-F]{2}[0-9a-fA-F]{2}[0-9a-fA-F]{2}$`)
 
-// ConvertHexToRGBA は 16 進数のカラーコードから color.RGBA を生成して返します。
+// ConvertHexToNRGBA は 16 進数のカラーコードから color.NRGBA を生成して返します。
 // hex はカラーコードです。#333 のような省略形は対応していません。
-func ConvertHexToRGBA(hex string) (color.RGBA, error) {
+func ConvertHexToNRGBA(hex string) (color.NRGBA, error) {
 
 	if ok := rgbaFormat.MatchString(hex); ok {
 		return parseColor(hex, true)
@@ -26,13 +26,13 @@ func ConvertHexToRGBA(hex string) (color.RGBA, error) {
 	if ok := rgbFormat.MatchString(hex); ok {
 		return parseColor(hex, false)
 	}
-	return color.RGBA{0, 0, 0, 0}, e.ErrorInvalidColorFormat
+	return color.NRGBA{0, 0, 0, 0}, e.ErrorInvalidColorFormat
 }
 
-// parseColor は 16 進数のカラーコードから color.RGBA を生成して返します。
+// parseColor は 16 進数のカラーコードから color.NRGBA を生成して返します。
 // hex はカラーコードです。#333 のような省略形は対応していません。
 // existAlpha はアルファ値を含むかどうかを指定します。true の場合はアルファ値を読み取り、false の場合はアルファ値は FF とします。
-func parseColor(hex string, existAlpha bool) (c color.RGBA, err error) {
+func parseColor(hex string, existAlpha bool) (c color.NRGBA, err error) {
 	err = nil
 	var a int64
 	a = 255
@@ -43,7 +43,6 @@ func parseColor(hex string, existAlpha bool) (c color.RGBA, err error) {
 			return
 		}
 	}
-	co := float64(a) / 255
 
 	r, err := strconv.ParseInt(hex[1:3], 16, 64)
 	if err != nil {
@@ -61,9 +60,9 @@ func parseColor(hex string, existAlpha bool) (c color.RGBA, err error) {
 		return c, err
 	}
 
-	c.R = uint8(float64(r) * co)
-	c.G = uint8(float64(g) * co)
-	c.B = uint8(float64(b) * co)
+	c.R = uint8(r)
+	c.G = uint8(g)
+	c.B = uint8(b)
 	c.A = uint8(a)
 	return
 }

--- a/internal/color/color_test.go
+++ b/internal/color/color_test.go
@@ -8,14 +8,14 @@ import (
 
 type tcase struct {
 	in   string
-	want color.RGBA
+	want color.NRGBA
 }
 
-func TestConvertHexToRGBA(t *testing.T) {
+func TestConvertHexToNRGBA(t *testing.T) {
 	cases := []tcase{
 		{
 			in: "#FF0000",
-			want: color.RGBA{
+			want: color.NRGBA{
 				R: uint8(255),
 				G: uint8(0),
 				B: uint8(0),
@@ -24,7 +24,7 @@ func TestConvertHexToRGBA(t *testing.T) {
 		},
 		{
 			in: "#00FF00",
-			want: color.RGBA{
+			want: color.NRGBA{
 				R: uint8(0),
 				G: uint8(255),
 				B: uint8(0),
@@ -33,7 +33,7 @@ func TestConvertHexToRGBA(t *testing.T) {
 		},
 		{
 			in: "#0000FF",
-			want: color.RGBA{
+			want: color.NRGBA{
 				R: uint8(0),
 				G: uint8(0),
 				B: uint8(255),
@@ -42,22 +42,22 @@ func TestConvertHexToRGBA(t *testing.T) {
 		},
 		{
 			in: "#FEC0AD80",
-			want: color.RGBA{
-				R: uint8(254 * 128 / 255),
-				G: uint8(192 * 128 / 255),
-				B: uint8(173 * 128 / 255),
+			want: color.NRGBA{
+				R: uint8(254),
+				G: uint8(192),
+				B: uint8(173),
 				A: uint8(128),
 			},
 		},
 	}
 
 	for _, c := range cases {
-		got, _ := ConvertHexToRGBA(c.in)
+		got, _ := ConvertHexToNRGBA(c.in)
 		assertColor(t, got, c.want)
 	}
 }
 
-func assertColor(t *testing.T, c color.RGBA, wc color.RGBA) {
+func assertColor(t *testing.T, c color.NRGBA, wc color.NRGBA) {
 	var got [4]uint32
 	got[0], got[1], got[2], got[3] = c.RGBA()
 	var want [4]uint32

--- a/internal/ogpgen/ogpgen.go
+++ b/internal/ogpgen/ogpgen.go
@@ -24,7 +24,7 @@ type OgpImage struct {
 	Font            *truetype.Font
 	BackgroundImage image.Image
 	FontSize        float64
-	FontColor       color.RGBA
+	FontColor       color.NRGBA
 	TopMargin       int
 	SideMargin      int
 	LineSpace       int
@@ -73,7 +73,7 @@ func NewOgpImage(opt Option) (o *OgpImage, err error) {
 	if opt.FontColor == "" {
 		opt.FontColor = "#000000"
 	}
-	c, err := c.ConvertHexToRGBA(opt.FontColor)
+	c, err := c.ConvertHexToNRGBA(opt.FontColor)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
- 文字色の指定時、color.NRGBA を使用するほうが直感的なので修正